### PR TITLE
Support newer vscode/vscodium versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "A theme as accurate to Github's dark theme as possible, but with purple accents!",
     "version": "0.0.15",
     "engines": {
-        "vscode": "^1.54.0"
+        "vscode": "^1.74.0"
     },
     "categories": [
         "Themes"


### PR DESCRIPTION
Just noticed my favorite theme is not available on newer versions. This makes the theme work when using them.